### PR TITLE
Autoconfig + rework layout

### DIFF
--- a/CalibrationBaliseForm.qml
+++ b/CalibrationBaliseForm.qml
@@ -1,15 +1,14 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
-import org.arig.robotmodel 1.0
 import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.1
 
+
 Page {
     id: page
-    width: 800
-    height: 430
+    anchors.fill: parent
 
-    title: qsTr("Calibration balise (Sauron)")
+    title: "Calibration balise"
 
     property var etalonnageDone: false
 
@@ -31,7 +30,7 @@ Page {
         anchors.rightMargin: 5
 
         Button {
-            text: qsTr("Photo")
+            text: "Photo"
             enabled: !RobotModel.updatePhoto && !RobotModel.etalonnageBalise
             highlighted: RobotModel.updatePhoto
             onClicked: {
@@ -49,7 +48,7 @@ Page {
         }
 
         Button {
-            text: qsTr("Étalonnage")
+            text: "Étalonnage"
             enabled: !RobotModel.updatePhoto && !RobotModel.etalonnageBalise
             highlighted: RobotModel.etalonnageBalise
             onClicked: {
@@ -60,7 +59,7 @@ Page {
         }
 
         Button {
-            text: qsTr("Valider")
+            text: "Valider"
             enabled: !RobotModel.updatePhoto && !RobotModel.etalonnageBalise && etalonnageDone
             highlighted: RobotModel.etalonnageOk
             onClicked: {
@@ -96,7 +95,7 @@ Page {
 
         Connections {
             target: RobotModel
-            onPhotoChanged: {
+            function onPhotoChanged() {
                 imgBalise.source = "data:image/jpeg;base64," + RobotModel.photo
             }
         }
@@ -113,10 +112,3 @@ Page {
     }
 
 }
-
-/*##^##
-Designer {
-    D{i:1;anchors_height:32}D{i:2;anchors_x:42;anchors_y:5}D{i:3;anchors_x:42;anchors_y:5}
-}
-##^##*/
-

--- a/ConfigurationForm.qml
+++ b/ConfigurationForm.qml
@@ -1,27 +1,17 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
-import org.arig.robotmodel 1.0
 import QtQuick.Layouts 1.1
+
 
 Page {
     id: page
     anchors.fill: parent
 
-    title: qsTr("Configuration Robots")
+    title: "Configuration " + ParamsModel.name
 
     function getBooleanColor(value, value2) {
         return value ? value2 === false ? "orange" : "green" : "red";
-    }
-
-    function getTeamColor(team) {
-        if (team === RobotModel.BLEU) {
-            return "blue";
-        } else if (team === RobotModel.JAUNE) {
-            return "yellow";
-        }
-
-        return Material.backgroundColor;
     }
 
     Popup {
@@ -87,381 +77,269 @@ Page {
         }
     }
 
-    Label {
-        id: lblMessage
-        height: 35
-        text: RobotModel.message
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        anchors.right: parent.right
-        anchors.rightMargin: 5
-        anchors.left: parent.left
-        anchors.leftMargin: 5
-        anchors.top: parent.top
-        anchors.topMargin: 5
-        font.pointSize: 16
-    }
-
-    Frame {
-        id: frameInfos
-        width: 395
-        anchors.left: parent.left
-        anchors.leftMargin: 5
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 190
-        anchors.top: lblMessage.bottom
-        anchors.topMargin: 10
-
-        Row {
-            id: rowStates
-            height: 180
-            spacing: 5
-            anchors.right: parent.right
-            anchors.rightMargin: 0
-            anchors.left: parent.left
-            anchors.leftMargin: 0
-            anchors.top: parent.top
-            anchors.topMargin: 0
-
-            Column {
-                width: 185
-                spacing: 10
-
-                StateComponent {
-                    id: i2cState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Bus i2c")
-                    stateColor: getBooleanColor(RobotModel.i2c)
-                }
-
-                StateComponent {
-                    id: lidarState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Lidar")
-                    stateColor: getBooleanColor(RobotModel.lidar)
-                }
-
-                StateComponent {
-                    id: otherRobotState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Odin")
-                    stateColor: getBooleanColor(RobotModel.otherRobot)
-                }
-
-                StateComponent {
-                    id: baliseState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Balise")
-                    stateColor: getBooleanColor(RobotModel.balise, RobotModel.etalonnageOk)
-                }
-            }
-
-            Column {
-                width: 185
-                spacing: 10
-
-                StateComponent {
-                    id: auState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("A.U.")
-                    stateColor: getBooleanColor(RobotModel.au)
-                }
-
-                StateComponent {
-                    id: alim12vState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Moteurs")
-                    stateColor: getBooleanColor(RobotModel.alim12v)
-                }
-
-                StateComponent {
-                    id: alim5vpState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Servos")
-                    stateColor: getBooleanColor(RobotModel.alim5vp)
-                }
-
-                StateComponent {
-                    id: tiretteState
-                    anchors.right: parent.right
-                    anchors.rightMargin: 5
-                    anchors.left: parent.left
-                    anchors.leftMargin: 5
-                    libelle: qsTr("Tirette")
-                    stateColor: getBooleanColor(RobotModel.tirette)
-                }
-            }
-        }
-    }
-
-    Frame {
-        id: frameTeam
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 190
-        anchors.top: lblMessage.bottom
-        anchors.topMargin: 10
-        anchors.right: parent.right
-        anchors.rightMargin: 5
-        anchors.left: frameInfos.right
-        anchors.leftMargin: 5
-
-        RowLayout {
-            anchors.bottom: buttonCalibration.top
-            anchors.bottomMargin: 0
-            anchors.top: parent.top
-            anchors.topMargin: 0
-            anchors.left: parent.left
-            anchors.leftMargin: 0
-            anchors.right: parent.right
-            anchors.rightMargin: 0
-
-            Rectangle {
-                id: rectColorTeamBleu
-                color: getTeamColor(RobotModel.BLEU)
-                opacity: RobotModel.team == RobotModel.BLEU ? 1 : 0.2
-                radius: 5
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                MouseArea {
-                    anchors.fill: parent
-                    enabled: !RobotModel.startCalibration
-                    onClicked: {
-                        RobotModel.team = RobotModel.BLEU
-                    }
-                }
-            }
-
-            Rectangle {
-                id: rectColorTeamJaune
-                color: getTeamColor(RobotModel.JAUNE)
-                opacity: RobotModel.team == RobotModel.JAUNE ? 1 : 0.2
-                radius: 5
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                MouseArea {
-                    anchors.fill: parent
-                    enabled: !RobotModel.startCalibration
-                    onClicked: {
-                        RobotModel.team = RobotModel.JAUNE
-                    }
-                }
-            }
-        }
+    ColumnLayout {
+        id: pageConfig
+        anchors.fill: parent
+        anchors.margins: 5
 
         Label {
-            id: lblTeam
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenterOffset: -30
-            anchors.verticalCenter: parent.verticalCenter
-            width: 300
-            height: 24
-            text: qsTr("Taper ici pour choisir l'équipe")
-            visible: RobotModel.team == RobotModel.UNKNOWN
-            verticalAlignment: Text.AlignVCenter
+            Layout.fillWidth: true
+            Layout.preferredHeight: 35
+            text: RobotModel.message
             horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
             font.pointSize: 16
         }
 
-        Button {
-            id: buttonCalibration
-            y: 277
-            enabled: RobotModel.au && RobotModel.team != RobotModel.UNKNOWN && !RobotModel.startCalibration
-            text: qsTr("Lancer le calage bordure")
-            hoverEnabled: false
-            highlighted: false
-            anchors.right: parent.right
-            anchors.rightMargin: 0
-            anchors.left: parent.left
-            anchors.leftMargin: 0
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 0
-            onClicked: {
-                if (!RobotModel.startCalibration) {
-                    console.log("Start calage bordure")
-                    calibConfirmation.open()
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.minimumHeight: 40*4 + 20
+            Layout.maximumHeight: 40*4 + 20
+
+            Frame {
+                id: statusFrame
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
+
+                RowLayout {
+                    anchors.fill: parent
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+
+                        StateComponent {
+                            id: i2cState
+                            libelle: "Bus i2c"
+                            stateColor: getBooleanColor(RobotModel.i2c)
+                        }
+
+                        StateComponent {
+                            id: lidarState
+                            libelle: "Lidar"
+                            stateColor: getBooleanColor(RobotModel.lidar)
+                        }
+
+                        StateComponent {
+                            id: otherRobotState
+                            libelle: ParamsModel.primary ? "Odin" : "Nerell"
+                            stateColor: getBooleanColor(RobotModel.otherRobot)
+                        }
+
+                        StateComponent {
+                            id: baliseState
+                            visible: ParamsModel.primary
+                            libelle: "Balise"
+                            stateColor: getBooleanColor(RobotModel.balise, RobotModel.etalonnageOk)
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 1
+
+                        StateComponent {
+                            id: auState
+                            libelle: "A.U."
+                            stateColor: getBooleanColor(RobotModel.au)
+                        }
+
+                        StateComponent {
+                            id: alim12vState
+                            libelle: "Moteurs"
+                            stateColor: getBooleanColor(RobotModel.alim12v)
+                        }
+
+                        StateComponent {
+                            id: alim5vpState
+                            libelle: "Servos"
+                            stateColor: getBooleanColor(RobotModel.alim5vp)
+                        }
+
+                        StateComponent {
+                            id: tiretteState
+                            visible: ParamsModel.primary || !RobotModel.otherRobot
+                            libelle: "Tirette"
+                            stateColor: getBooleanColor(RobotModel.tirette)
+                        }
+                    }
+                }
+            }
+
+            Frame {
+                id: teamFrame
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
+
+                Label {
+                    anchors.fill: parent
+                    anchors.bottomMargin: 40
+                    text: "Taper ici pour choisir l'équipe"
+                    visible: !RobotModel.team && (ParamsModel.primary || !RobotModel.otherRobot)
+                    verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pointSize: 16
+                }
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+
+                        Repeater {
+                            model: ParamsModel.teams
+
+                            delegate: Rectangle {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                Layout.preferredWidth: 1
+                                color: modelData.color
+                                opacity: RobotModel.team === modelData.name ? 1 : 0.2
+                                radius: 5
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    enabled: !RobotModel.startCalibration && (ParamsModel.primary || !RobotModel.otherRobot)
+                                    onClicked: {
+                                        RobotModel.team = modelData.name
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Button {
+                        Layout.fillWidth: true
+                        topInset: 5
+                        bottomInset: 0
+                        bottomPadding: 5
+                        enabled: RobotModel.au && !!RobotModel.team && !RobotModel.startCalibration && (ParamsModel.primary || !RobotModel.otherRobot)
+                        text: "Lancer le calage bordure"
+                        hoverEnabled: false
+                        highlighted: false
+                        onClicked: {
+                            if (!RobotModel.startCalibration) {
+                                console.log("Start calage bordure")
+                                calibConfirmation.open()
+                            }
+                        }
+                    }
                 }
             }
         }
-    }
 
-    Frame {
-        id: frameConfig
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
-        anchors.top: frameTeam.bottom
-        anchors.topMargin: 5
-        anchors.right: parent.right
-        anchors.rightMargin: 5
-        anchors.left: parent.left
-        anchors.leftMargin: 5
-        topPadding: 0
-        bottomPadding: 0
-
-
-        ButtonGroup {
-            buttons: strategies.childrens
-        }
-
-        Row {
-            id: rowConfig
-            spacing: 10
+        RowLayout {
+            Layout.fillWidth: true
             enabled: !RobotModel.tirette
-            anchors.right: parent.right
-            anchors.rightMargin: 0
-            anchors.left: parent.left
-            anchors.leftMargin: 0
-            anchors.top: parent.top
-            anchors.topMargin: 0
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 0
 
-            Column {
-                id: strategies
-                width: 170
-                spacing: 0
-                anchors.top: parent.top
-                anchors.topMargin: 0
+            Frame {
+                id: strategiesFrame
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
 
-                RadioButton {
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
+                ColumnLayout {
+                    anchors.top: parent.top
                     anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    checked: RobotModel.strategy === RobotModel.BASIC
-                    text: qsTr("Basic")
-                    font.pointSize: 16
-                    onClicked: RobotModel.strategy = RobotModel.BASIC
-                }
-                RadioButton {
                     anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    checked: RobotModel.strategy === RobotModel.AGGRESSIVE
-                    text: qsTr("Aggressive")
-                    font.pointSize: 16
-                    onClicked: RobotModel.strategy = RobotModel.AGGRESSIVE
-                }
-                RadioButton {
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    checked: RobotModel.strategy === RobotModel.FINALE
-                    text: qsTr("Finale")
-                    font.pointSize: 16
-                    onClicked: RobotModel.strategy = RobotModel.FINALE
+
+                    Repeater {
+                        model: ParamsModel.strategies
+
+                        delegate: RadioButton {
+                            padding: 5
+                            text: modelData
+                            font.pointSize: 16
+                            checked: RobotModel.strategy === modelData
+                            onClicked: RobotModel.strategy = modelData
+                        }
+                    }
                 }
             }
 
-            Column {
-                id: configMatch
-                width: 235
-                spacing: 10
+            Frame {
+                id: configMatchFrame
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
 
-                Switch {
-                    id: configDeposePartielle
-                    text: qsTr("Dépose partielle gd chenal")
-                    checked: RobotModel.deposePartielle && RobotModel.twoRobots
-                    enabled: RobotModel.twoRobots
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
+                ColumnLayout {
+                    anchors.top: parent.top
                     anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.deposePartielle = configDeposePartielle.checked
-                    onCheckedChanged: RobotModel.deposePartielle = configDeposePartielle.checked
-                }
+                    anchors.right: parent.right
+                    spacing: 0
 
-                Switch {
-                    id: configEchangeEcueil
-                    text: qsTr("Échange ecueil")
-                    checked: RobotModel.echangeEcueil
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.echangeEcueil = configEchangeEcueil.checked
-                }
+                    Repeater {
+                        model: ParamsModel.options
 
-                Switch {
-                    id: configSafeAvoidance
-                    text: qsTr("Safe avoidance")
-                    checked: RobotModel.safeAvoidance
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.safeAvoidance = configSafeAvoidance.checked
+                        delegate: Switch {
+                            id: optionItem
+                            padding: 5
+                            text: modelData
+                            checked: RobotModel.options[modelData]
+                            onClicked: RobotModel.setOption(modelData, optionItem.checked)
+                        }
+                    }
                 }
             }
 
-            Column {
-                id: configDebug
-                width: 200
-                spacing: 10
+            Frame {
+                id: configDebugFrame
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
 
-                Switch {
-                    id: configTwoRobots
-                    text: qsTr("Deux robots")
-                    enabled: !RobotModel.otherRobot
-                    checked: RobotModel.twoRobots
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
+                ColumnLayout {
+                    anchors.top: parent.top
                     anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.twoRobots = configTwoRobots.checked
-                }
+                    anchors.right: parent.right
+                    spacing: 0
 
-                Switch {
-                    id: configSkipCalageChoixStrat
-                    text: qsTr("Skip cal. bord. / strat.")
-                    checked: RobotModel.skipCalageBordure
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.skipCalageBordure = configSkipCalageChoixStrat.checked
-                }
+                    Switch {
+                        id: configTwoRobots
+                        padding: 5
+                        text: "Deux robots"
+                        enabled: !RobotModel.otherRobot
+                        checked: RobotModel.twoRobots
+                        onClicked: RobotModel.twoRobots = configTwoRobots.checked
+                    }
 
-                Switch {
-                    id: configModeManuel
-                    text: qsTr("Mode manuel")
-                    checked: RobotModel.modeManuel
-                    anchors.right: parent.right
-                    anchors.rightMargin: 0
-                    anchors.left: parent.left
-                    anchors.leftMargin: 0
-                    onClicked: RobotModel.modeManuel = configModeManuel.checked
+                    Switch {
+                        id: configSafeAvoidance
+                        padding: 5
+                        text: "Safe avoidance"
+                        checked: RobotModel.safeAvoidance
+                        onClicked: RobotModel.safeAvoidance = configSafeAvoidance.checked
+                    }
+
+                    Switch {
+                        id: configSkipCalageChoixStrat
+                        padding: 5
+                        text: qsTr("Skip cal. bord. / strat.")
+                        checked: RobotModel.skipCalageBordure
+                        onClicked: RobotModel.skipCalageBordure = configSkipCalageChoixStrat.checked
+                    }
+
+                    Switch {
+                        id: configModeManuel
+                        padding: 5
+                        text: qsTr("Mode manuel")
+                        checked: RobotModel.modeManuel
+                        onClicked: RobotModel.modeManuel = configModeManuel.checked
+                    }
                 }
-           }
+            }
         }
     }
 
     Frame {
-        id: matchInfos
+        id: pageMatch
         visible: false
         anchors.fill: parent
         background: Image {
@@ -506,27 +384,12 @@ Page {
             when: (RobotModel.inMatch)
 
             PropertyChanges {
-                target: lblMessage
+                target: pageConfig
                 visible: false
             }
 
             PropertyChanges {
-                target: frameInfos
-                visible: false
-            }
-
-            PropertyChanges {
-                target: frameTeam
-                visible: false
-            }
-
-            PropertyChanges {
-                target: frameConfig
-                visible: false
-            }
-
-            PropertyChanges {
-                target: matchInfos
+                target: pageMatch
                 visible: true
             }
 
@@ -537,20 +400,3 @@ Page {
         }
     ]
 }
-
-
-
-
-/*##^##
-Designer {
-    D{i:0;autoSize:true;height:480;width:640}D{i:2;anchors_width:145;anchors_x:"-9";anchors_y:3}
-D{i:3;anchors_width:356;anchors_x:393;anchors_y:"-1"}D{i:4;anchors_width:145;anchors_x:"-9";anchors_y:3}
-D{i:5;anchors_width:356;anchors_x:393;anchors_y:"-1"}D{i:6;anchors_width:145;anchors_x:"-9";anchors_y:3}
-D{i:7;anchors_width:356;anchors_x:393;anchors_y:"-1"}D{i:8;anchors_width:145;anchors_x:"-9";anchors_y:3}
-D{i:10;anchors_width:145;anchors_x:"-9";anchors_y:3}D{i:11;anchors_width:356;anchors_x:393;anchors_y:"-1"}
-D{i:9;anchors_width:356;anchors_x:393;anchors_y:"-1"}D{i:1;anchors_height:332;anchors_x:35;anchors_y:34}
-D{i:12;anchors_width:356;anchors_x:5;anchors_y:59}D{i:22;anchors_width:180;anchors_x:264}
-D{i:23;anchors_width:180;anchors_x:264}D{i:20;anchors_x:16}D{i:27;anchors_height:42}
-D{i:28;anchors_height:42;anchors_width:200;anchors_x:0}D{i:31;anchors_width:200;anchors_x:0}
-}
-##^##*/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,78 @@
 
 ```
 robots-gui unix /tmp/ecran.sock [debug]
+robots-gui inet 9000 [debug]
 ```
 
 ## Messages JSON
+
+### Paramétrage initial
+
+* Query
+```json
+{
+    "action": "SET_PARAMS",
+    "data": {
+        "name": "Nerell",
+        "primary": true,
+        "teams": {
+            "BLEU": "#00f",
+            "JAUNE": "#0ff"
+        },
+        "strategies": [
+            "BASIC",
+            "AGRESSIVE"
+        ],
+        "options": [
+            "option1",
+            "option2"
+        ]
+    }
+}
+```
+
+* Réponse
+```json
+{
+    "status": "OK",
+    "action": "SET_PARAMS",
+}
+```
+
+### Mettre à jour les informations d'init
+
+* Query
+```json
+{
+    "action": "UPDATE_STATE",
+    "data": {
+    "au": true,
+        "message": "Démarrage",
+        "i2c": true,
+        "alim12v": true,
+        "alim5vp": true,
+        "tirette": true,
+        "lidar": true,
+        "balise": true,
+        "otherRobot": true,
+        // si non primary
+        "team": "JAUNE",
+        "strategy": "BASIC",
+        "options": {
+            "option1": true,
+            "option2": false
+        }
+    }
+}
+```
+
+* Réponse
+```json
+{
+    "status": "OK",
+    "action": "UPDATE_STATE"
+}
+```
 
 ### Récupérer la configuration
 
@@ -22,46 +91,21 @@ robots-gui unix /tmp/ecran.sock [debug]
     "action": "GET_CONFIG",
     "data": {
         "team": "JAUNE",
+        "strategy": "BASIC",
+        "exit": false,
+        "twoRobots": true,
+        "safeAvoidance": true,
         "startCalibration": false,
-        "strategy": "STRAT1",
         "modeManuel": false,
         "skipCalageBordure": false,
         "updatePhoto": false,
-        "etalionnageBalise": false,
-        "posEcueil": [
-            [500, 500],
-            [500, 500]
-        ],
-        "posBouees": [ ... ] // six positions ou null
+        "etalonnageBalise": false,
+        "etalonnageOk": false,
+        "options": {
+            "option1": true,
+            "option2": false
+        }
     }
-}
-```
-
-### Mettre à jour les informations d'init
-
-* Query
-```json
-{
-    "action": "UPDATE_STATE",
-    "data": {
-        "i2c": true,
-        "lidar": true,
-        "au": true,
-        "alim12v": true,
-        "alim5vp": true,
-        "tirette": true,
-        "otherRobot": true,
-        "balise": true,
-        "message": "Démarrage"
-    }
-}
-```
-
-* Réponse
-```json
-{
-    "status": "OK",
-    "action": "UPDATE_STATE"
 }
 ```
 
@@ -93,6 +137,7 @@ robots-gui unix /tmp/ecran.sock [debug]
 {
     "action": "UPDATE_PHOTO",
     "data": {
+        "message": null,
         "photo": "jpeg en base64 sans l'en-tete"
     }
 }
@@ -103,26 +148,5 @@ robots-gui unix /tmp/ecran.sock [debug]
 {
     "status": "OK",
     "action": "UPDATE_PHOTO"
-}
-```
-
-### Mettre à jour le résultat d'étalonnage balise
-
-* Query
-```json
-{
-    "action": "UPDATE_ETALONNAGE",
-    "data": {
-        "ecueil": ["#ff00ff00", "#ffff0000"],
-        "bouees": [ ... ] // six couleurs ou null
-    }
-}
-```
-
-* Réponse
-```json
-{
-    "status": "OK",
-    "action": "UPDATE_ETALONNAGE"
 }
 ```

--- a/StateComponent.qml
+++ b/StateComponent.qml
@@ -1,49 +1,26 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.1
 
-Item {
-    id: element
-    height: 35
+RowLayout {
+    Layout.maximumHeight: 35
+    Layout.minimumHeight: 35
 
     property string libelle: libelle
     property string stateColor: "gray"
-    width: 300
 
     Label {
-        id: lblTxt
-        x: -2
-        y: -2
+        Layout.fillWidth: true
+        Layout.fillHeight: true
         text: libelle
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
         font.pointSize: 16
         verticalAlignment: Text.AlignVCenter
-        anchors.top: parent.top
-        anchors.topMargin: 0
-        anchors.right: rectState.left
-        anchors.rightMargin: 5
-        anchors.left: parent.left
-        anchors.leftMargin: 0
     }
 
     Rectangle {
-        id: rectState
-        x: 331
-        y: -2
+        Layout.fillHeight: true
         width: 35
         color: stateColor
         radius: 10
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
-        anchors.top: parent.top
-        anchors.topMargin: 0
-        anchors.right: parent.right
-        anchors.rightMargin: 0
     }
 }
-
-/*##^##
-Designer {
-    D{i:1;anchors_height:35}D{i:2;anchors_height:35}
-}
-##^##*/

--- a/common.h
+++ b/common.h
@@ -17,6 +17,7 @@ using json = nlohmann::json;
 
 #define ACTION_EXIT           "EXIT"
 #define ACTION_ECHO           "ECHO"
+#define ACTION_SET_PARAMS     "SET_PARAMS"
 #define ACTION_GET_CONFIG     "GET_CONFIG"
 #define ACTION_UPDATE_STATE   "UPDATE_STATE"
 #define ACTION_UPDATE_MATCH   "UPDATE_MATCH"

--- a/main.qml
+++ b/main.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.5
-import org.arig.robotmodel 1.0
 
 
 ApplicationWindow {
@@ -12,7 +11,7 @@ ApplicationWindow {
     height: 480
     maximumHeight: 480
     minimumHeight: 480
-    title: qsTr("Robots GUI")
+    title: "ARIG Robot GUI"
 
     header: ToolBar {
         id: toolBar
@@ -20,61 +19,33 @@ ApplicationWindow {
         visible: !RobotModel.inMatch
 
         ToolButton {
-            id: toolButton
-            text: stackView.depth > 1 ? "\u25C0" : "\u2630"
+            visible: stackView.depth > 1
+            text: "\u25C0"
             font.pixelSize: Qt.application.font.pixelSize * 1.6
-            onClicked: {
-                if (stackView.depth > 1) {
-                    stackView.pop()
-                } else {
-                    drawer.open()
-                }
-            }
+            onClicked: stackView.pop()
         }
 
         ToolButton {
-            id: baliseButton
             text: "Calibration"
-            anchors.left: toolButton.left
             anchors.leftMargin: 50
             font.pixelSize: Qt.application.font.pixelSize * 1.6
-            enabled: RobotModel.balise && stackView.currentItem.title !== "Calibration balise (Sauron)"
-            onClicked: {
-                console.log(stackView.currentItem)
-                stackView.push("CalibrationBaliseForm.qml")
-            }
+            visible: ParamsModel.primary && stackView.currentItem.title !== "Calibration balise"
+            enabled: RobotModel.balise
+            onClicked: stackView.push("CalibrationBaliseForm.qml")
         }
 
         Label {
             text: stackView.currentItem.title
+            font.pixelSize: Qt.application.font.pixelSize * 1.6
             anchors.centerIn: parent
         }
 
         ToolButton {
+            id: toolButton
             text: "\u274c"
             font.pixelSize: Qt.application.font.pixelSize * 1.6
             anchors.right: parent.right
             onClicked: exitConfirmation.open()
-        }
-    }
-
-    Drawer {
-        id: drawer
-        width: window.width * 0.2
-        height: window.height
-
-        Column {
-            anchors.fill: parent
-
-            ItemDelegate {
-                text: qsTr("Calibration Balise")
-                width: parent.width
-                enabled: RobotModel.balise
-                onClicked: {
-                    stackView.push("CalibrationBaliseForm.qml")
-                    drawer.close()
-                }
-            }
         }
     }
 

--- a/paramsmodel.cpp
+++ b/paramsmodel.cpp
@@ -1,0 +1,56 @@
+#include "paramsmodel.h"
+#include "common.h"
+
+ParamsModel* ParamsModel::instance = nullptr;
+
+ParamsModel* ParamsModel::getInstance() {
+    if (instance == nullptr) {
+        instance = new ParamsModel();
+    }
+    return instance;
+}
+
+ParamsModel::ParamsModel(QObject *parent) : QObject(parent) {
+    this->setName("...");
+    this->setPrimary(false);
+}
+
+QString ParamsModel::getName() {
+    return this->name;
+}
+void ParamsModel::setName(QString name) {
+    this->name = name;
+    emit nameChanged(name);
+}
+
+bool ParamsModel::getPrimary() {
+    return this->primary;
+}
+void ParamsModel::setPrimary(bool primary) {
+    this->primary = primary;
+    emit primaryChanged(primary);
+}
+
+QList<TeamAndColor> ParamsModel::getTeams() {
+    return this->teams;
+}
+void ParamsModel::setTeams(QList<TeamAndColor> teams) {
+    this->teams = teams;
+    emit teamsChanged(teams);
+}
+
+QStringList ParamsModel::getStrategies() {
+    return this->strategies;
+}
+void ParamsModel::setStrategies(QStringList strategies) {
+    this->strategies = strategies;
+    emit strategiesChanged(strategies);
+}
+
+QStringList ParamsModel::getOptions() {
+    return this->options;
+}
+void ParamsModel::setOptions(QStringList options) {
+    this->options = options;
+    emit optionsChanged(options);
+}

--- a/paramsmodel.h
+++ b/paramsmodel.h
@@ -1,0 +1,84 @@
+#ifndef PARAMSMODEL_H
+#define PARAMSMODEL_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QJSEngine>
+#include <QString>
+#include <QPoint>
+#include <QMap>
+
+class TeamAndColor
+{
+    Q_GADGET
+
+    Q_PROPERTY(QString name READ getName)
+    Q_PROPERTY(QString color READ getColor)
+
+private:
+    QString name, color;
+
+public:
+    TeamAndColor() {}
+    TeamAndColor(QString _name, QString _color) : name(_name), color(_color) {}
+
+    QString getName() {
+        return name;
+    }
+
+    QString getColor() {
+        return color;
+    }
+
+};
+
+Q_DECLARE_METATYPE(TeamAndColor);
+
+class ParamsModel : public QObject
+{
+    Q_OBJECT
+
+private:
+    Q_PROPERTY(QString name READ getName NOTIFY nameChanged)
+    Q_PROPERTY(bool primary READ getPrimary NOTIFY primaryChanged)
+    Q_PROPERTY(QList<TeamAndColor> teams READ getTeams NOTIFY teamsChanged)
+    Q_PROPERTY(QStringList strategies READ getStrategies NOTIFY strategiesChanged)
+    Q_PROPERTY(QStringList options READ getOptions NOTIFY optionsChanged)
+
+    static ParamsModel* instance;
+    ParamsModel(QObject *parent = nullptr);
+
+public:
+    static ParamsModel* getInstance();
+
+    QString getName();
+    void setName(QString name);
+
+    bool getPrimary();
+    void setPrimary(bool primary);
+
+    QList<TeamAndColor> getTeams();
+    void setTeams(QList<TeamAndColor> teams);
+
+    QStringList getStrategies();
+    void setStrategies(QStringList strategies);
+
+    QStringList getOptions();
+    void setOptions(QStringList options);
+
+signals:
+    void nameChanged(QString newValue);
+    void primaryChanged(bool newValue);
+    void teamsChanged(QList<TeamAndColor> newValue);
+    void strategiesChanged(QStringList newValue);
+    void optionsChanged(QStringList newValue);
+
+private:
+    QString name;
+    bool primary;
+    QList<TeamAndColor> teams;
+    QStringList strategies, options;
+
+};
+
+#endif // PARAMSMODEL_H

--- a/robotmodel.cpp
+++ b/robotmodel.cpp
@@ -10,24 +10,12 @@ RobotModel* RobotModel::getInstance() {
     return instance;
 }
 
-QObject* RobotModel::singletonProvider(QQmlEngine *engine, QJSEngine *scriptEngine) {
-    Q_UNUSED(scriptEngine)
-
-    auto instance = RobotModel::getInstance();
-    engine->setObjectOwnership(instance, QQmlEngine::CppOwnership);
-    return instance;
-}
-
 RobotModel::RobotModel(QObject *parent) : QObject(parent) {
     // RW
     this->setExit(false);
-    this->setTeam(UNKNOWN);
-    this->setStrategy(BASIC);
     this->setStartCalibration(false);
     this->setModeManuel(false);
     this->setSafeAvoidance(true);
-    this->setDeposePartielle(false);
-    this->setEchangeEcueil(false);
     this->setSkipCalageBordure(false);
     this->setUpdatePhoto(false);
     this->setEtalonnageBalise(false);
@@ -59,10 +47,10 @@ void RobotModel::setExit(bool exit) {
     emit exitChanged(exit);
 }
 
-RobotModel::Team RobotModel::getTeam() {
+QString RobotModel::getTeam() {
     return this->team;
 }
-void RobotModel::setTeam(Team team) {
+void RobotModel::setTeam(QString team) {
     this->team = team;
     emit teamChanged(team);
 }
@@ -75,10 +63,10 @@ void RobotModel::setStartCalibration(bool value) {
     emit startCalibrationChanged(value);
 }
 
-RobotModel::Strategy RobotModel::getStrategy() {
+QString RobotModel::getStrategy() {
     return this->strategy;
 }
-void RobotModel::setStrategy(Strategy strategy) {
+void RobotModel::setStrategy(QString strategy) {
     this->strategy = strategy;
     emit strategyChanged(strategy);
 }
@@ -105,22 +93,6 @@ bool RobotModel::getSafeAvoidance() {
 void RobotModel::setSafeAvoidance(bool value) {
     this->safeAvoidance = value;
     emit safeAvoidanceChanged(value);
-}
-
-bool RobotModel::getDeposePartielle() {
-    return this->deposePartielle;
-}
-void RobotModel::setDeposePartielle(bool value) {
-    this->deposePartielle = value;
-    emit deposePartielleChanged(value);
-}
-
-bool RobotModel::getEchangeEcueil() {
-    return this->echangeEcueil;
-}
-void RobotModel::setEchangeEcueil(bool value) {
-    this->echangeEcueil = value;
-    emit echangeEcueilChanged(value);
 }
 
 bool RobotModel::getUpdatePhoto() {
@@ -153,6 +125,19 @@ bool RobotModel::getTwoRobots() {
 void RobotModel::setTwoRobots(bool value) {
     this->twoRobots = value;
     emit twoRobotsChanged(value);
+}
+
+QVariantMap RobotModel::getOptions() {
+    return this->options;
+}
+void RobotModel::setOptions(QVariantMap value) {
+    this->options = value;
+    emit optionsChanged(value);
+}
+
+void RobotModel::setOption(QString name, bool value) {
+    this->options.insert(name, value);
+    emit optionsChanged(this->options);
 }
 
 // QML RO data //

--- a/robotmodel.h
+++ b/robotmodel.h
@@ -5,34 +5,27 @@
 #include <QQmlEngine>
 #include <QJSEngine>
 #include <QString>
-#include <QPoint>
+#include <QVariantMap>
+
 
 class RobotModel : public QObject
 {
     Q_OBJECT
 
-public:
-    enum Team { UNKNOWN, JAUNE, BLEU };
-    enum Strategy { BASIC, AGGRESSIVE, FINALE };
-
-    Q_ENUM(Team)
-    Q_ENUM(Strategy)
-
 private:
     // RW
     Q_PROPERTY(bool exit READ getExit WRITE setExit NOTIFY exitChanged)
-    Q_PROPERTY(Team team READ getTeam WRITE setTeam NOTIFY teamChanged)
-    Q_PROPERTY(Strategy strategy READ getStrategy WRITE setStrategy NOTIFY strategyChanged)
+    Q_PROPERTY(QString team READ getTeam WRITE setTeam NOTIFY teamChanged)
+    Q_PROPERTY(QString strategy READ getStrategy WRITE setStrategy NOTIFY strategyChanged)
     Q_PROPERTY(bool startCalibration READ getStartCalibration WRITE setStartCalibration NOTIFY startCalibrationChanged)
     Q_PROPERTY(bool skipCalageBordure READ getSkipCalageBordure WRITE setSkipCalageBordure NOTIFY skipCalageBordureChanged)
     Q_PROPERTY(bool modeManuel READ getModeManuel WRITE setModeManuel NOTIFY modeManuelChanged)
     Q_PROPERTY(bool safeAvoidance READ getSafeAvoidance WRITE setSafeAvoidance NOTIFY safeAvoidanceChanged)
-    Q_PROPERTY(bool deposePartielle READ getDeposePartielle WRITE setDeposePartielle NOTIFY deposePartielleChanged)
-    Q_PROPERTY(bool echangeEcueil READ getEchangeEcueil WRITE setEchangeEcueil NOTIFY echangeEcueilChanged)
     Q_PROPERTY(bool updatePhoto READ getUpdatePhoto WRITE setUpdatePhoto NOTIFY updatePhotoChanged)
     Q_PROPERTY(bool etalonnageBalise READ getEtalonnageBalise WRITE setEtalonnageBalise NOTIFY etalonnageBaliseChanged)
     Q_PROPERTY(bool etalonnageOk READ getEtalonnageOk WRITE setEtalonnageOk NOTIFY etalonnageOkChanged)
     Q_PROPERTY(bool twoRobots READ getTwoRobots WRITE setTwoRobots NOTIFY twoRobotsChanged)
+    Q_PROPERTY(QVariantMap options READ getOptions WRITE setOptions NOTIFY optionsChanged)
 
     // RO
     Q_PROPERTY(bool au READ getAu NOTIFY auChanged)
@@ -53,21 +46,20 @@ private:
     RobotModel(QObject *parent = nullptr);
 
 public:
-    static QObject* singletonProvider(QQmlEngine *engine = nullptr, QJSEngine *scriptEngine = nullptr);
     static RobotModel* getInstance();
 
     // RW
     bool getExit();
     void setExit(bool value);
 
-    Team getTeam();
-    void setTeam(Team team);
+    QString getTeam();
+    void setTeam(QString team);
 
     bool getStartCalibration();
     void setStartCalibration(bool value);
 
-    Strategy getStrategy();
-    void setStrategy(Strategy strategy);
+    QString getStrategy();
+    void setStrategy(QString strategy);
 
     bool getSkipCalageBordure();
     void setSkipCalageBordure(bool value);
@@ -77,12 +69,6 @@ public:
 
     bool getSafeAvoidance();
     void setSafeAvoidance(bool value);
-
-    bool getDeposePartielle();
-    void setDeposePartielle(bool value);
-
-    bool getEchangeEcueil();
-    void setEchangeEcueil(bool value);
 
     bool getUpdatePhoto();
     void setUpdatePhoto(bool value);
@@ -95,6 +81,12 @@ public:
 
     bool getTwoRobots();
     void setTwoRobots(bool value);
+
+    QVariantMap getOptions();
+    void setOptions(QVariantMap value);
+
+    Q_INVOKABLE void setOption(QString name, bool value);
+
 
     // RO
     bool getInMatch();
@@ -139,18 +131,17 @@ public:
 signals:
     // RW
     void exitChanged(bool newValue);
-    void teamChanged(Team newTeam);
-    void strategyChanged(Strategy strategy);
+    void teamChanged(QString newValue);
+    void strategyChanged(QString newValue);
     void startCalibrationChanged(bool newValue);
     void skipCalageBordureChanged(bool newValue);
     void modeManuelChanged(bool newValue);
     void safeAvoidanceChanged(bool newValue);
-    void deposePartielleChanged(bool newValue);
-    void echangeEcueilChanged(bool newValue);
     void updatePhotoChanged(bool newValue);
     void etalonnageBaliseChanged(bool newValue);
     void etalonnageOkChanged(bool newValue);
     void twoRobotsChanged(bool newValue);
+    void optionsChanged(QVariantMap newValue);
 
     // RO
     void i2cChanged(bool newValue);
@@ -171,9 +162,9 @@ public slots:
 
 private:
     // RW
-    Team team;
-    Strategy strategy;
-    bool exit, startCalibration, modeManuel, skipCalageBordure, safeAvoidance, deposePartielle, echangeEcueil, updatePhoto, etalonnageBalise, etalonnageOk, twoRobots;
+    QString team, strategy;
+    bool exit, startCalibration, modeManuel, skipCalageBordure, safeAvoidance, updatePhoto, etalonnageBalise, etalonnageOk, twoRobots;
+    QVariantMap options;
 
     // RO
     int score;

--- a/socketthread.cpp
+++ b/socketthread.cpp
@@ -136,8 +136,12 @@ void SocketThread::run() {
                 robotModel->setTwoRobots(true);
 
                 if (!paramsModel->getPrimary()) {
-                    robotModel->setTeam(QString::fromStdString(data["team"]));
-                    robotModel->setStrategy(QString::fromStdString(data["strategy"]));
+                    if (!data["team"].is_null()) {
+                        robotModel->setTeam(QString::fromStdString(data["team"]));
+                    }
+                    if (!data["strategy"].is_null()) {
+                        robotModel->setStrategy(QString::fromStdString(data["strategy"]));
+                    }
 
                     for (auto &opt : data["options"].items()) {
                         robotModel->setOption(QString::fromStdString(opt.key()), opt.value());


### PR DESCRIPTION
J'ai pu avoir deux Run configuration différentes avec les options
- unix /tmp/ecran-nerell.sock
- unix /tmp/ecran-odin.sock

et ainsi lancer les deux écrans en même temps, vu que c'est le même binaire, pas de problème.

J'imagine que c'est pareil pour la configuration de déploiement, à tester.

Il faudra changer le nom du projet et dépot en `robot-gui`, ainsi que changer le nom du binaire dans les `application.yaml`